### PR TITLE
Assortment of fixes - particularly for reading saved cctree.out

### DIFF
--- a/plugin/cctree.vim
+++ b/plugin/cctree.vim
@@ -1820,26 +1820,30 @@ function! s:XRefTracer.mGetSymbolIdXRef(symid, direction) dict
     return symidslist
 endfunction
 
-function! s:XRefTracer.mGrowTree(rtree, 
+function! s:XRefTracer.mGrowTree(rtree, curdepth, maxdepth,
                                       \ direction, pbar) dict
     if !has_key(a:rtree, 'childlinks')
         call self.mBuildTree(a:rtree, 1, 1,
                     \ a:direction, a:pbar)
     else
         for entry in a:rtree['childlinks'] 
-            call self.mGrowTree(entry,
+            call self.mGrowTree(entry, a:curdepth+1, a:maxdepth,
                         \ a:direction, a:pbar)
         endfor
     endif
 endfunction
 
-function! s:XRefTracer.mPruneTree(rtree, 
+function! s:XRefTracer.mPruneTree(rtree, curdepth, maxdepth,
                                       \ direction, pbar) dict
     if !has_key(a:rtree, 'childlinks')
-        return -1
+        if a:curdepth > a:maxdepth
+            return -1
+        else
+            return 0
+        endif
     else
         for entry in a:rtree['childlinks'] 
-            if (self.mPruneTree(entry,
+            if (self.mPruneTree(entry, a:curdepth+1, a:maxdepth,
                         \ a:direction, a:pbar) == -1) 
                 call remove(a:rtree['childlinks'], 0)
             endif
@@ -3142,10 +3146,10 @@ function! s:CCTreeGlobals.mGetCallsForTreeNode(rtree, action, depth, direction) 
         call xtracer.mBuildTree(a:rtree, 0, a:depth, 
                     \ a:direction, pbar)
     elseif a:action == 'expand'
-        call xtracer.mGrowTree(a:rtree, 
+        call xtracer.mGrowTree(a:rtree, 0, a:depth,
                     \ a:direction, pbar)
     elseif a:action == 'prune'
-        call xtracer.mPruneTree(a:rtree, 
+        call xtracer.mPruneTree(a:rtree, 0, a:depth,
                     \ a:direction, pbar)
     endif
     call xtracer.mDoneTracing()
@@ -3215,7 +3219,7 @@ endfunction
 
 function! s:CCTreeGlobals.mRecursiveDepthModify(action) dict
     call self.mGetCallsForTreeNode(self.PreviewState.rootNode,
-                \ a:action, 1, self.PreviewState.direction)
+                \ a:action, self.PreviewState.depth, self.PreviewState.direction)
     call self.Window.mDisplayTree(self.PreviewState.rootNode,
                 \ self.PreviewState.direction)
 endfunction

--- a/plugin/cctree.vim
+++ b/plugin/cctree.vim
@@ -1823,7 +1823,7 @@ endfunction
 function! s:XRefTracer.mGrowTree(rtree, curdepth, maxdepth,
                                       \ direction, pbar) dict
     if !has_key(a:rtree, 'childlinks')
-        call self.mBuildTree(a:rtree, 1, 1,
+        call self.mBuildTree(a:rtree, 0, 1,
                     \ a:direction, a:pbar)
     else
         for entry in a:rtree['childlinks'] 
@@ -1857,7 +1857,7 @@ endfunction
 
 function! s:XRefTracer.mBuildTree(rtree, curdepth, maxdepth,
                                       \ direction, pbar) dict
-    if (a:curdepth > a:maxdepth)
+    if (a:curdepth >= a:maxdepth)
         return {}
     endif
 

--- a/plugin/cctree.vim
+++ b/plugin/cctree.vim
@@ -1812,6 +1812,9 @@ endfunction
 
 function! s:XRefTracer.mGetSymbolIdXRef(symid, direction) dict
     let acctreesym = self.xrefdb.mGetSymbolFromId(a:symid)
+    if empty(acctreesym)
+	    return []
+    endif
     let symidslist = split(
                     \s:CCTreeMakeCommaListUnique(acctreesym[a:direction]), ",")
     return symidslist
@@ -1859,10 +1862,12 @@ function! s:XRefTracer.mBuildTree(rtree, curdepth, maxdepth,
     for entry in self.mGetSymbolIdXRef(a:rtree.symid, a:direction)
         call a:pbar.mTick(1)
         let symname = self.xrefdb.mGetSymbolFromId(entry)
-        let ctree = s:CallTreeNode.mCreate(symname['n'], entry)
-        call self.mBuildTree(ctree, a:curdepth+1, a:maxdepth,
-                                            \a:direction, a:pbar)
-        call s:CallTreeUtils.mAddChildLink(a:rtree, ctree)
+	if !empty(symname)
+		let ctree = s:CallTreeNode.mCreate(symname['n'], entry)
+		call self.mBuildTree(ctree, a:curdepth+1, a:maxdepth,
+						    \a:direction, a:pbar)
+		call s:CallTreeUtils.mAddChildLink(a:rtree, ctree)
+	endif
     endfor
 endfunction
 

--- a/plugin/cctree.vim
+++ b/plugin/cctree.vim
@@ -3277,7 +3277,7 @@ function! s:CCTreeGlobals.mWriteXRefDbToFile(fname) dict
     " create db serializer and writer
     let gDbSz = s:GenericDbSerializer.mCreate(self.XRefDb)
     let gDbWriter = s:CCTreeTagDbWriter.mCreate(
-                                \ s:CCTreeGetXRefDbMaps('Compress', 'Alpha'))
+                                \ s:CCTreeGetXRefDbMaps('Uncompress', 'Numeric'))
     call gDbSz.mWriteXRefDbToFile(a:fname, gDbWriter)
 endfunction
 

--- a/plugin/cctree.vim
+++ b/plugin/cctree.vim
@@ -1533,7 +1533,7 @@ function! s:GenericDbSerializer.mWriteSymsToFile(dstVFile,
                                                     \ "items")
     call a:gWriter.mInitWriting()
     " write syms
-    for asymid in sort(self.xrefdb.mGetSymbolIds())
+    for asymid in sort(self.xrefdb.mGetSymbolIds(), 'N')
         let  acctreesym = self.xrefdb.mGetSymbolFromId(asymid)
         call a:dstVFile.mWriteLine(a:gWriter.mBuildTagLine(acctreesym,
                         \ asymid))
@@ -1566,7 +1566,7 @@ endfunction
 function! s:CCTreeTagDbWriter.mBuildHeader() dict
     let hdr = []
     call add(hdr, "!_TAG_FILE_FORMAT\t2\t/extended format; --format=1 will not append ;\" to lines/")
-    call add(hdr, "!_TAG_FILE_SORTED\t1\t/0=unsorted, 1=sorted, 2=foldcase/")
+    call add(hdr, "!_TAG_FILE_SORTED\t0\t/0=unsorted, 1=sorted, 2=foldcase/")
     call add(hdr, "!_TAG_PROGRAM_NAME\t\tCCTree (Vim plugin)//")
     call add(hdr, "!_TAG_PROGRAM_URL\thttp://vim.sourceforge.net/scripts/script.php?script_id=2368\t/site/")
     return hdr


### PR DESCRIPTION
I started with not being able to use the saved cctree.out as in #16 and ended up with a bit extra fixes on top. Which I'm not sure how good they are - particularly the one about sorting. taglist() fails to find lots of elements and I literally hacked it to reduce the error rate, but not entirely eleminated it.

It seems this project is no longer maintained - but hey in case anyone finds this useful..